### PR TITLE
bug-fix for cmake file and empty training set check

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -41,7 +41,11 @@ endif()
 
 set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast")
-   
+
+
+add_library("opencv_dep_cudart" UNKNOWN IMPORTED)
+set_target_properties("opencv_dep_cudart" PROPERTIES IMPORTED_LOCATION /usr/local/cuda/lib64/libcudart.so)  
+
 add_executable(train_obj 
     train_obj.cpp
     util.cpp

--- a/core/test_ransac.cpp
+++ b/core/test_ransac.cpp
@@ -63,6 +63,13 @@ int main(int argc, const char* argv[])
     std::vector<std::string> testSets = getSubPaths(dataDir);
     std::cout << std::endl << BLUETEXT("Loading test set ...") << std::endl;
     jp::Dataset testDataset = jp::Dataset(testSets[0], 1);
+
+    //check if test set is  empty
+    if(!testDataset.size())
+    {
+        std::cout << std::endl << REDTEXT("The test set is empty!") << std::endl;
+        return 0;
+    }
         
     // lua and models
     std::cout << "Loading script: " << baseScriptObj << std::endl;    

--- a/core/train_obj.cpp
+++ b/core/train_obj.cpp
@@ -226,6 +226,13 @@ int main(int argc, const char* argv[])
     std::cout << std::endl << BLUETEXT("Loading training set ...") << std::endl;
     jp::Dataset trainDataset = jp::Dataset(trainingSets[0], 1);
 
+    //check if the traning set is empty
+    if (!trainDataset.size())  
+    {
+        std::cout << std::endl << REDTEXT("The training set is empty !") << std::endl;
+        return 0;
+    }
+
     #if DOVALIDATION
     std::string validationDir = dataDir + "validation/";
 

--- a/core/train_ransac.cpp
+++ b/core/train_ransac.cpp
@@ -73,6 +73,14 @@ int main(int argc, const char* argv[])
     std::vector<std::string> trainingSets = getSubPaths(trainingDir);
     std::cout << std::endl << BLUETEXT("Loading training set ...") << std::endl;
     jp::Dataset trainingDataset = jp::Dataset(trainingSets[0], 1);
+
+
+    //check if the traning set is empty
+    if (!trainingDataset.size())  
+    {
+        std::cout << std::endl << REDTEXT("The training set is empty") << std::endl;
+        return 0;
+    }
     
     #if DOVALIDATION
     std::string validationDir = dataDir + "validation/";


### PR DESCRIPTION
Hi, there
     I'm reading the paper and successfully complied your source code, achieving a pretty good result. However I found a few detail are missing in your code.

Im using 
Ubuntu 16.04 
gcc 5.4
cuda8.0
cudnn6.0
gnu make 4.1



4 changes are made by me:
1: core/CMakeLists.txt
This error would occur if I type the command: 

` cmake ..`

error message:

admin-bai@adminbai-OMEN-by-HP-Desktop-PC-880-p1xx:~/Documents/DSAC/core/build$ cmake ..
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.8")
-- Found PNG: /usr/lib/x86_64-linux-gnu/libpng.so (found version "1.2.54")
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Found CUDA: /usr/local/cuda (found suitable exact version "8.0")
-- OpenCV Include Directory: /usr/local/include/opencv;/usr/local/include
-- OpenCV Link Libraries: opencv_videostab;opencv_video;opencv_ts;opencv_superres;opencv_stitching;opencv_photo;opencv_ocl;opencv_objdetect;opencv_nonfree;opencv_ml;opencv_legacy;opencv_imgproc;opencv_highgui;opencv_gpu;opencv_flann;opencv_features2d;opencv_core;opencv_contrib;opencv_calib3d
-- Try OpenMP C flag = [-fopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Success
-- Try OpenMP CXX flag = [-fopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Success
-- Found OpenMP: -fopenmp
-- Configuring done
-- Generating done
-- Build files have been written to: /home/admin-bai/Documents/DSAC/core/build
admin-bai@adminbai-OMEN-by-HP-Desktop-PC-880-p1xx:~/Documents/DSAC/core/build$ make -j30
Scanning dependencies of target train_obj
Scanning dependencies of target train_ransac_softam
Scanning dependencies of target test_ransac
Scanning dependencies of target test_ransac_softam
Scanning dependencies of target train_score
Scanning dependencies of target train_ransac
[  2%] Building CXX object CMakeFiles/test_ransac.dir/dataset.cpp.o
[  6%] Building CXX object CMakeFiles/test_ransac.dir/Hypothesis.cpp.o
[  6%] Building CXX object CMakeFiles/test_ransac.dir/read_data.cpp.o
[  8%] Building CXX object CMakeFiles/test_ransac.dir/util.cpp.o
[ 10%] Building CXX object CMakeFiles/train_ransac_softam.dir/util.cpp.o
[ 12%] Building CXX object CMakeFiles/train_ransac.dir/train_ransac.cpp.o
[ 18%] Building CXX object CMakeFiles/train_obj.dir/util.cpp.o
[ 18%] Building CXX object CMakeFiles/test_ransac.dir/thread_rand.cpp.o
[ 14%] Building CXX object CMakeFiles/train_score.dir/Hypothesis.cpp.o
[ 37%] Building CXX object CMakeFiles/test_ransac.dir/properties.cpp.o
[ 37%] Building CXX object CMakeFiles/test_ransac_softam.dir/Hypothesis.cpp.o
[ 20%] Building CXX object CMakeFiles/test_ransac.dir/test_ransac.cpp.o
[ 22%] Building CXX object CMakeFiles/train_ransac_softam.dir/Hypothesis.cpp.o
[ 25%] Building CXX object CMakeFiles/train_obj.dir/train_obj.cpp.o
[ 29%] Building CXX object CMakeFiles/train_score.dir/dataset.cpp.o
[ 39%] Building CXX object CMakeFiles/train_ransac_softam.dir/thread_rand.cpp.o
[ 31%] Building CXX object CMakeFiles/test_ransac_softam.dir/properties.cpp.o
[ 31%] Building CXX object CMakeFiles/test_ransac_softam.dir/dataset.cpp.o
[ 33%] Building CXX object CMakeFiles/test_ransac_softam.dir/util.cpp.o
[ 41%] Building CXX object CMakeFiles/test_ransac_softam.dir/test_ransac_softam.cpp.o
[ 43%] Building CXX object CMakeFiles/train_obj.dir/dataset.cpp.o
[ 47%] Building CXX object CMakeFiles/train_score.dir/properties.cpp.o
[ 45%] Building CXX object CMakeFiles/train_ransac_softam.dir/dataset.cpp.o
[ 50%] Building CXX object CMakeFiles/train_obj.dir/Hypothesis.cpp.o
[ 52%] Building CXX object CMakeFiles/train_score.dir/util.cpp.o
[ 56%] Building CXX object CMakeFiles/train_score.dir/train_score.cpp.o
[ 54%] Building CXX object CMakeFiles/train_obj.dir/properties.cpp.o
[ 58%] Building CXX object CMakeFiles/train_ransac_softam.dir/train_ransac_softam.cpp.o
[ 60%] Building CXX object CMakeFiles/train_ransac_softam.dir/properties.cpp.o
[ 62%] Building CXX object CMakeFiles/train_ransac_softam.dir/read_data.cpp.o
[ 64%] Building CXX object CMakeFiles/train_score.dir/read_data.cpp.o
[ 66%] Building CXX object CMakeFiles/train_score.dir/thread_rand.cpp.o
[ 68%] Building CXX object CMakeFiles/train_obj.dir/read_data.cpp.o
[ 70%] Building CXX object CMakeFiles/train_obj.dir/thread_rand.cpp.o
[ 72%] Building CXX object CMakeFiles/test_ransac_softam.dir/read_data.cpp.o
[ 75%] Building CXX object CMakeFiles/test_ransac_softam.dir/thread_rand.cpp.o
[ 77%] Building CXX object CMakeFiles/train_ransac.dir/util.cpp.o
[ 79%] Building CXX object CMakeFiles/train_ransac.dir/dataset.cpp.o
[ 81%] Building CXX object CMakeFiles/train_ransac.dir/Hypothesis.cpp.o
[ 83%] Building CXX object CMakeFiles/train_ransac.dir/properties.cpp.o
[ 85%] Building CXX object CMakeFiles/train_ransac.dir/read_data.cpp.o
[ 87%] Building CXX object CMakeFiles/train_ransac.dir/thread_rand.cpp.o
[ 89%] Linking CXX executable test_ransac
/usr/bin/ld: cannot find -lopencv_dep_cudart
collect2: error: ld returned 1 exit status
CMakeFiles/test_ransac.dir/build.make:274: recipe for target 'test_ransac' failed
make[2]: *** [test_ransac] Error 1
CMakeFiles/Makefile2:252: recipe for target 'CMakeFiles/test_ransac.dir/all' failed
make[1]: *** [CMakeFiles/test_ransac.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 91%] Linking CXX executable train_ransac_softam
[ 93%] Linking CXX executable train_obj
/usr/bin/ld: cannot find -lopencv_dep_cudart
collect2: error: ld returned 1 exit status
CMakeFiles/train_ransac_softam.dir/build.make:274: recipe for target 'train_ransac_softam' failed
make[2]: *** [train_ransac_softam] Error 1
CMakeFiles/Makefile2:215: recipe for target 'CMakeFiles/train_ransac_softam.dir/all' failed
make[1]: *** [CMakeFiles/train_ransac_softam.dir/all] Error 2
[ 95%] Linking CXX executable train_score
[ 97%] Linking CXX executable train_ransac
/usr/bin/ld: cannot find -lopencv_dep_cudart
collect2: error: ld returned 1 exit status
CMakeFiles/train_obj.dir/build.make:274: recipe for target 'train_obj' failed
make[2]: *** [train_obj] Error 1
CMakeFiles/Makefile2:104: recipe for target 'CMakeFiles/train_obj.dir/all' failed
make[1]: *** [CMakeFiles/train_obj.dir/all] Error 2
/usr/bin/ld: cannot find -lopencv_dep_cudart
collect2: error: ld returned 1 exit status
CMakeFiles/train_score.dir/build.make:274: recipe for target 'train_score' failed
make[2]: *** [train_score] Error 1
CMakeFiles/Makefile2:141: recipe for target 'CMakeFiles/train_score.dir/all' failed
make[1]: *** [CMakeFiles/train_score.dir/all] Error 2
/usr/bin/ld: cannot find -lopencv_dep_cudart
collect2: error: ld returned 1 exit status
CMakeFiles/train_ransac.dir/build.make:274: recipe for target 'train_ransac' failed
make[2]: *** [train_ransac] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/train_ransac.dir/all' failed
make[1]: *** [CMakeFiles/train_ransac.dir/all] Error 2
[100%] Linking CXX executable test_ransac_softam
/usr/bin/ld: cannot find -lopencv_dep_cudart
collect2: error: ld returned 1 exit status
CMakeFiles/test_ransac_softam.dir/build.make:274: recipe for target 'test_ransac_softam' failed
make[2]: *** [test_ransac_softam] Error 1
CMakeFiles/Makefile2:178: recipe for target 'CMakeFiles/test_ransac_softam.dir/all' failed
make[1]: *** [CMakeFiles/test_ransac_softam.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2 

I don't have a libopencv_dep_cudart.so file  in my computer, so I add these two lines below to the CMakeList.txt
`add_library("opencv_dep_cudart" UNKNOWN IMPORTED)
set_target_properties("opencv_dep_cudart" PROPERTIES IMPORTED_LOCATION /usr/local/cuda/lib64/libcudart.so)  `
and it worked. I think it's the different version of CUDA causing this bug(not sure).

Other 3 changes are basically the same:
Check if the trainDataset/testDataset  is empty, when no training/test  files are replaced under DSAC-master/7scenes folder, the program will crush without warning, so I think it's better to add an empty check to  warn the user.

                                                                                                                     Best Wishes